### PR TITLE
AMReX: >= {{ version }}

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,6 +1,6 @@
 {% set name = "pyamrex" %}
 {% set version = "23.10" %}
-{% set build = 6 %}
+{% set build = 7 %}
 
 # ensure mpi is defined (needed for conda-smithy recipe-lint)
 {% set mpi = mpi or 'nompi' %}
@@ -70,7 +70,7 @@ requirements:
     # wrappers are bash scripts and wrappers in build can't use host libraries.
     - openmpi  # [mpi == "openmpi" and (build_platform != target_platform)]
   host:
-    - amrex {{ version }} {{ mpi_prefix }}_*
+    - amrex >={{ version }} {{ mpi_prefix }}_*
     - {{ mpi }}  # [mpi != 'nompi']
     - numpy
     - pip
@@ -79,7 +79,7 @@ requirements:
     - setuptools
     - wheel
   run:
-    - amrex {{ version }} {{ mpi_prefix }}_*
+    - amrex >={{ version }} {{ mpi_prefix }}_*
     - {{ mpi }}  # [mpi != 'nompi']
     - mpi4py     # [mpi != 'nompi']
     - {{ pin_compatible('numpy') }}


### PR DESCRIPTION
Since AMReX has binary pinning (runtime/ABI break protection), we can specify to use AMReX at a certain version or newer as build dependency. This will mostly work unless there are API breaks and simplifies months in which we, potentially, have no new pyAMReX release but a new regular AMReX release.

I think due to our AMReX pinning, this is not needed:
https://docs.conda.io/projects/conda-build/en/stable/resources/variants.html#pinning-at-the-recipe-level

We can simply check this in a few months, trying to install older versions after newer releases dropped.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
