### PR TITLE
Fix: Linux `libgomp`

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Package license: BSD-3-Clause-LBNL
 
 Summary: GPU-Enabled, Zero-Copy AMReX Python Bindings including AI/ML
 
-Development: ttps://github.com/AMReX-Codes/pyamrex
+Development: https://github.com/AMReX-Codes/pyamrex
 
 Documentation: https://pyamrex.readthedocs.io/
 

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -50,7 +50,6 @@ requirements:
     - if: osx
       then: llvm-openmp
     - cmake
-    - curl
     - pkg-config
     # In OpenMPI, the compiler wrappers are binaries and the wrappers in build
     # can use host libraries by adding OPAL_PREFIX and in mpich, compiler

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -45,6 +45,8 @@ requirements:
         - lld
         - llvm-openmp
         - ninja
+    - if: linux
+      then: libgomp
     - if: osx
       then: llvm-openmp
     - cmake


### PR DESCRIPTION
Explicitly depend on GCC OpenMP on Linux.

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [ ] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [ ] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
