### PR TITLE
Fix Use-After-Free in `to_numpy`

### DIFF
--- a/recipe/478.patch
+++ b/recipe/478.patch
@@ -1,0 +1,65 @@
+From da9d3a4a54c6063869ad59b8ae2698fe6aaa63a1 Mon Sep 17 00:00:00 2001
+From: Axel Huebl <axel.huebl@plasma.ninja>
+Date: Wed, 17 Sep 2025 16:03:46 -0700
+Subject: [PATCH] Fix Use-After-Free in NumPy/df
+
+For AoS and SoA `.to_numpy()` and dependent logic
+like `.to_df()`, the lifetime of the temporary copied
+variable is only handled by NumPy if we first create
+a named variable.
+
+The `to_host()` returned object is a temporary, and
+`np.array` using the `__array_interface__` protocol does
+not keep it alive automatically unless it is stored
+in an actual variable (eg., `tmp`).
+---
+ src/amrex/extensions/ArrayOfStructs.py | 12 ++++++++----
+ src/amrex/extensions/PODVector.py      | 12 ++++++++----
+ 2 files changed, 16 insertions(+), 8 deletions(-)
+
+diff --git a/src/amrex/extensions/ArrayOfStructs.py b/src/amrex/extensions/ArrayOfStructs.py
+index 54afb0d4..401550d3 100644
+--- a/src/amrex/extensions/ArrayOfStructs.py
++++ b/src/amrex/extensions/ArrayOfStructs.py
+@@ -32,10 +32,14 @@ def aos_to_numpy(self, copy=False):
+     if copy:
+         # This supports a device-to-host copy.
+         #
+-        # todo: validate of the to_host() returned object
+-        #       lifetime is always managed correctly by
+-        #       Python's GC - otherwise copy twice via copy=True
+-        return np.array(self.to_host(), copy=False)
++        # The to_host() returned object is a temporary, and
++        # np.array using the __array_interface__ protocol does
++        # not keep it alive automatically unless it is stored
++        # in an actual variable (tmp).
++        tmp = self.to_host()
++        ret = np.array(tmp, copy=False)
++        assert ret.base is tmp
++        return ret
+     else:
+         return np.array(self, copy=False)
+ 
+diff --git a/src/amrex/extensions/PODVector.py b/src/amrex/extensions/PODVector.py
+index 667b52c9..06ac3824 100644
+--- a/src/amrex/extensions/PODVector.py
++++ b/src/amrex/extensions/PODVector.py
+@@ -29,10 +29,14 @@ def podvector_to_numpy(self, copy=False):
+         if copy:
+             # This supports a device-to-host copy.
+             #
+-            # todo: validate of the to_host() returned object
+-            #       lifetime is always managed correctly by
+-            #       Python's GC - otherwise copy twice via copy=True
+-            return np.array(self.to_host(), copy=False)
++            # The to_host() returned object is a temporary, and
++            # np.array using the __array_interface__ protocol does
++            # not keep it alive automatically unless it is stored
++            # in an actual variable (tmp).
++            tmp = self.to_host()
++            ret = np.array(tmp, copy=False)
++            assert ret.base is tmp
++            return ret
+         else:
+             return np.array(self, copy=False)
+     else:

--- a/recipe/recipe.yaml
+++ b/recipe/recipe.yaml
@@ -5,7 +5,7 @@ schema_version: 1
 context:
   name: pyamrex
   version: "25.09"
-  build: 1
+  build: 2
   mpi: ${{ mpi or "nompi" }}  # is this still needed?
   mpi_prefix: ${{ "nompi" if mpi == "nompi" else "mpi_" + mpi }}
 
@@ -16,6 +16,10 @@ package:
 source:
   url: https://github.com/AMReX-Codes/pyamrex/archive/refs/tags/${{ version }}.tar.gz
   sha256: 5ae257ed32300decdfb77d6487f74509167c65102cb61ae7528716d7da2ea263
+  patches:
+    # fix use-after-free in to_numpy
+    # https://github.com/AMReX-Codes/pyamrex/pull/478
+    - 478.patch
 
 build:
   skip: python_impl == "pypy"


### PR DESCRIPTION
See https://github.com/AMReX-Codes/pyamrex/pull/478 and https://github.com/conda-forge/impactx-feedstock/pull/56#issuecomment-3304382067

<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [ ] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
